### PR TITLE
Add slash to fix file.relative on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var fs = require("fs");
 var gutil = require("gulp-util");
 var PluginError = gutil.PluginError;
 var Concat  = require("concat-with-sourcemaps");
+var slash = require('slash');
 
 module.exports = function(options) {
 
@@ -40,13 +41,13 @@ module.exports = function(options) {
             latestMod = file.stat && file.stat.mtime;
         }
 
-        concat.add(null, prefix.replace(/{file-relative}/g, "./" + file.relative));
+        concat.add(null, prefix.replace(/{file-relative}/g, "./" + slash(file.relative)));
         if (file.relative.endsWith(".json")) {
             concat.add(null, "module.exports = ");
-            concat.add(file.relative, file.contents, file.sourceMap);
+            concat.add(slash(file.relative), file.contents, file.sourceMap);
             concat.add(null, ";");
         } else {
-            concat.add(file.relative, file.contents, file.sourceMap);
+            concat.add(slash(file.relative), file.contents, file.sourceMap);
         }
         concat.add(null, suffix);
 

--- a/package.json
+++ b/package.json
@@ -1,31 +1,32 @@
 {
-    "name": "gulp-concat-js",
-    "version": "0.1.0",
-    "description": "Gulp plugin for concatenating javascript with sourcemaps",
-    "homepage": "http://github.com/totokaka/gulp-concat-js",
-    "repository": "git://github.com/totokaka/gulp-concat-js.git",
-    "main": "index.js",
-    "files": [
-        "index.js",
-        "lib/*.js"
-    ],
-    "keywords": [
-        "gulpplugin",
-        "gulp",
-        "sourcemaps",
-        "obfuscator",
-        "obfuscate",
-        "concat",
-        "concatenating"
-    ],
-    "author": "totokaka <mail@totokaka.io>",
-    "license": "MIT",
-    "dependencies": {
-        "concat-with-sourcemaps": "^1.0.0",
-        "gulp-util": "^3.0.1",
-        "through2": "^0.6.3"
-    },
-    "devDependencies": {
-        "gulp": "^3.8.7"
-    }
+  "name": "gulp-concat-js",
+  "version": "0.1.0",
+  "description": "Gulp plugin for concatenating javascript with sourcemaps",
+  "homepage": "http://github.com/totokaka/gulp-concat-js",
+  "repository": "git://github.com/totokaka/gulp-concat-js.git",
+  "main": "index.js",
+  "files": [
+    "index.js",
+    "lib/*.js"
+  ],
+  "keywords": [
+    "gulpplugin",
+    "gulp",
+    "sourcemaps",
+    "obfuscator",
+    "obfuscate",
+    "concat",
+    "concatenating"
+  ],
+  "author": "totokaka <mail@totokaka.io>",
+  "license": "MIT",
+  "dependencies": {
+    "concat-with-sourcemaps": "^1.0.0",
+    "gulp-util": "^3.0.1",
+    "slash": "^1.0.0",
+    "through2": "^0.6.3"
+  },
+  "devDependencies": {
+    "gulp": "^3.8.7"
+  }
 }


### PR DESCRIPTION
Use slash to fix path generated by file.relative on windows.

File.relative is (afaik) a getter which computes its value from base and path (using path.relative) and on windows this generates a path with backslashes which then fails any require leading to that path.

I honestly do not know if this belongs here but since the property file.relative is computed, it cannot be set without dirty hacks or without passing new vinyl objects, which seems a bit much for this issue.